### PR TITLE
refactor: use telemq_ prefix for dependencies

### DIFF
--- a/authenticator_http/Cargo.toml
+++ b/authenticator_http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "authenticator_http"
+name = "telemq_authenticator_http"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,4 +10,4 @@ log = "0.4"
 reqwest = { version = "0.11", features = ["json"] }
 
 # telemq dependencies
-plugin_types = { path = "../plugin_types", version = "0.1", features = ["authenticator"] }
+telemq_plugin_types = { path = "../plugin_types", version = "0.1", features = ["authenticator"] }

--- a/authenticator_http/src/lib.rs
+++ b/authenticator_http/src/lib.rs
@@ -1,7 +1,7 @@
 use log::error;
 use reqwest::Client;
 
-use plugin_types::authenticator::*;
+use telemq_plugin_types::authenticator::*;
 
 pub async fn connect<'a>(
     url: &String,

--- a/plugin_types/Cargo.toml
+++ b/plugin_types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "plugin_types"
+name = "telemq_plugin_types"
 version = "0.1.0"
 edition = "2021"
 

--- a/telemq/Cargo.toml
+++ b/telemq/Cargo.toml
@@ -35,8 +35,8 @@ reqwest = { version = "0.11", features = ["json"] }
 warp = { version = "0.3", features = ["tls"] }
 
 mqtt-packets = { path = "../mqtt-packets", version = "0.1.0", features = ["v_3_1_1"] }
-plugin_types = { path = "../plugin_types", version = "0.1", features = ["authenticator"] }
-authenticator_http = { path = "../authenticator_http", version = "0.1" }
+telemq_plugin_types = { path = "../plugin_types", version = "0.1", features = ["authenticator"] }
+telemq_authenticator_http = { path = "../authenticator_http", version = "0.1" }
 
 [dev-dependencies]
 maplit = "1"

--- a/telemq/src/authenticator/authenticator.rs
+++ b/telemq/src/authenticator/authenticator.rs
@@ -1,7 +1,7 @@
 use log::info;
 use std::net::SocketAddr;
 
-use plugin_types::authenticator::{
+use telemq_plugin_types::authenticator::{
     AuthenticatorResult, LoginRequest, LoginResponse, TopicACL, TopicAccess,
 };
 
@@ -73,7 +73,7 @@ impl Authenticator {
                         username: &username,
                         password: &password,
                     };
-                    return authenticator_http::connect(addr, req).await;
+                    return telemq_authenticator_http::connect(addr, req).await;
                 }
 
                 None => self.anonymous_allowed,

--- a/telemq/src/connection.rs
+++ b/telemq/src/connection.rs
@@ -9,7 +9,7 @@ use crate::{
     transaction::TransactionSendState,
 };
 
-use plugin_types::authenticator::{LoginResponse as AuthenticatorConnectResponse, TopicAccess};
+use telemq_plugin_types::authenticator::{LoginResponse as AuthenticatorConnectResponse, TopicAccess};
 
 // FIXME: define logging levels
 use log::{error, info};


### PR DESCRIPTION
Rename local crates:

* `plugin_types` to `telemq_plugin_types`
* `authenticator_http` to `telemq_authenticator_http`

to avoid conflicts when publishing